### PR TITLE
Add Anthropic usage provider

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "file:///home/igorw/Work/opencode-plugins-dev/usage/dist/index.js",
-    "@howaboua/create-opencode-plugin@latest"
+    "file:///home/igorw/Work/opencode-plugins-dev/usage/src/index.ts",
+    "@howaboua/create-opencode-plugin@1.0.1"
   ]
 }

--- a/src/hooks/command.ts
+++ b/src/hooks/command.ts
@@ -60,6 +60,7 @@ export function commandHooks(options: {
         if (s.provider === "codex") return options.state.availableProviders.codex
         if (s.provider === "proxy") return options.state.availableProviders.proxy
         if (s.provider === "copilot") return options.state.availableProviders.copilot
+        if (s.provider === "anthropic") return options.state.availableProviders.anthropic
         return true
       })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export const UsagePlugin: Plugin = async ({ client }) => {
     state.availableProviders.codex = usageConfig?.providers?.openai !== false
     state.availableProviders.proxy = usageConfig?.providers?.proxy !== false
     state.availableProviders.copilot = usageConfig?.providers?.copilot !== false
+    state.availableProviders.anthropic = usageConfig?.providers?.anthropic !== false
   } catch (err) {}
 
   async function sendStatusMessage(sessionID: string, text: string): Promise<void> {

--- a/src/providers/anthropic/fetch.ts
+++ b/src/providers/anthropic/fetch.ts
@@ -1,0 +1,61 @@
+/**
+ * HTTP client for Anthropic subscription usage endpoints.
+ * Fetches usage windows and profile data via OAuth bearer token.
+ */
+
+import type { AnthropicAuth, AnthropicUsageResponse, AnthropicProfileResponse } from "./types"
+
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+const PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
+const BETA_HEADER = "oauth-2025-04-20"
+const USER_AGENT = "claude-code/2.0.32"
+const DEFAULT_TIMEOUT = 10_000
+
+function buildHeaders(auth: AnthropicAuth): Record<string, string> {
+  return {
+    "Authorization": `Bearer ${auth.access}`,
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+    "User-Agent": USER_AGENT,
+    "anthropic-beta": BETA_HEADER,
+  }
+}
+
+async function fetchWithTimeout(url: string, headers: Record<string, string>, timeout = DEFAULT_TIMEOUT): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeout)
+
+  try {
+    return await fetch(url, {
+      method: "GET",
+      headers,
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+export async function fetchAnthropicUsage(auth: AnthropicAuth): Promise<AnthropicUsageResponse> {
+  const headers = buildHeaders(auth)
+  const response = await fetchWithTimeout(USAGE_URL, headers)
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`Anthropic usage request failed: HTTP ${response.status}${body ? ` - ${body}` : ""}`)
+  }
+
+  return (await response.json()) as AnthropicUsageResponse
+}
+
+export async function fetchAnthropicProfile(auth: AnthropicAuth): Promise<AnthropicProfileResponse> {
+  const headers = buildHeaders(auth)
+  const response = await fetchWithTimeout(PROFILE_URL, headers)
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(`Anthropic profile request failed: HTTP ${response.status}${body ? ` - ${body}` : ""}`)
+  }
+
+  return (await response.json()) as AnthropicProfileResponse
+}

--- a/src/providers/anthropic/index.ts
+++ b/src/providers/anthropic/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Anthropic subscription provider for usage tracking.
+ * Supports Free, Pro, Max, Team, and Enterprise plan tiers.
+ * Fetches usage windows (5h, 7d, opus, sonnet, cowork) and profile data.
+ */
+
+import type { UsageProvider } from "../base"
+import type { UsageSnapshot, AnthropicQuota } from "../../types"
+import type { AnthropicAuth, AnthropicPlanTier, AnthropicProfileResponse, AnthropicUsageResponse } from "./types"
+import { fetchAnthropicUsage, fetchAnthropicProfile } from "./fetch"
+
+export type { AnthropicAuth } from "./types"
+
+/**
+ * Resolve the plan tier from the profile response.
+ * Handles all known Anthropic subscription types.
+ */
+function resolvePlanTier(profile: AnthropicProfileResponse | null): AnthropicPlanTier {
+  if (!profile) return "unknown"
+
+  const { account, organization } = profile
+  const orgType = organization.organization_type?.toLowerCase() ?? ""
+
+  if (orgType.includes("enterprise")) return "enterprise"
+  if (orgType.includes("team")) return "team"
+  if (account.has_claude_max) return "max"
+  if (account.has_claude_pro) return "pro"
+  if (orgType.includes("pro")) return "pro"
+  if (orgType.includes("max")) return "max"
+  if (orgType.includes("free")) return "free"
+
+  return "unknown"
+}
+
+/**
+ * Build the AnthropicQuota from the usage response.
+ * Captures all usage windows including model-specific ones.
+ */
+function buildAnthropicQuota(usage: AnthropicUsageResponse, profile: AnthropicProfileResponse | null) {
+  return {
+    fiveHour: usage.five_hour
+      ? { utilization: usage.five_hour.utilization, resetsAt: usage.five_hour.resets_at }
+      : null,
+    sevenDay: usage.seven_day
+      ? { utilization: usage.seven_day.utilization, resetsAt: usage.seven_day.resets_at }
+      : null,
+    sevenDayOAuthApps: usage.seven_day_oauth_apps
+      ? { utilization: usage.seven_day_oauth_apps.utilization, resetsAt: usage.seven_day_oauth_apps.resets_at }
+      : null,
+    sevenDayOpus: usage.seven_day_opus
+      ? { utilization: usage.seven_day_opus.utilization, resetsAt: usage.seven_day_opus.resets_at }
+      : null,
+    sevenDaySonnet: usage.seven_day_sonnet
+      ? { utilization: usage.seven_day_sonnet.utilization, resetsAt: usage.seven_day_sonnet.resets_at }
+      : null,
+    sevenDayCowork: usage.seven_day_cowork
+      ? { utilization: usage.seven_day_cowork.utilization, resetsAt: usage.seven_day_cowork.resets_at }
+      : null,
+    iguanaNecktie: usage.iguana_necktie
+      ? { utilization: usage.iguana_necktie.utilization, resetsAt: usage.iguana_necktie.resets_at }
+      : null,
+    extraUsage: usage.extra_usage
+      ? {
+          isEnabled: usage.extra_usage.is_enabled,
+          monthlyLimit: usage.extra_usage.monthly_limit,
+          usedCredits: usage.extra_usage.used_credits,
+          utilization: usage.extra_usage.utilization,
+        }
+      : null,
+    planTier: resolvePlanTier(profile),
+    organizationType: profile?.organization.organization_type ?? null,
+    subscriptionStatus: profile?.organization.subscription_status ?? null,
+    accountEmail: profile?.account.email ?? null,
+  }
+}
+
+
+
+export const AnthropicProvider: UsageProvider<AnthropicAuth> = {
+  id: "anthropic",
+  displayName: "Anthropic Subscription",
+
+  async fetchUsage(auth: AnthropicAuth): Promise<UsageSnapshot | null> {
+    try {
+      // Fetch usage and profile in parallel; profile is non-critical
+      const [usage, profile] = await Promise.all([
+        fetchAnthropicUsage(auth),
+        fetchAnthropicProfile(auth).catch(() => null),
+      ])
+
+      const planTier = resolvePlanTier(profile)
+
+      return {
+        timestamp: Date.now(),
+        provider: "anthropic",
+        planType: planTier === "unknown" ? null : planTier as any,
+        primary: usage.five_hour
+          ? {
+              usedPercent: usage.five_hour.utilization,
+              windowMinutes: 300,
+              resetsAt: usage.five_hour.resets_at
+                ? Math.floor(new Date(usage.five_hour.resets_at).getTime() / 1000)
+                : null,
+            }
+          : null,
+        secondary: usage.seven_day
+          ? {
+              usedPercent: usage.seven_day.utilization,
+              windowMinutes: 10080,
+              resetsAt: usage.seven_day.resets_at
+                ? Math.floor(new Date(usage.seven_day.resets_at).getTime() / 1000)
+                : null,
+            }
+          : null,
+        codeReview: null,
+        credits: null,
+        anthropicQuota: buildAnthropicQuota(usage, profile),
+        updatedAt: Date.now(),
+      }
+    } catch {
+      return null
+    }
+  },
+}

--- a/src/providers/anthropic/types.ts
+++ b/src/providers/anthropic/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Type definitions for the Anthropic subscription usage provider.
+ * Covers all plan tiers: Free, Pro, Max, Team, Enterprise.
+ */
+
+/** Auth credentials for Anthropic OAuth */
+export interface AnthropicAuth {
+  access: string
+  refresh?: string
+}
+
+/** A single usage window from the /api/oauth/usage endpoint */
+export interface AnthropicUsageWindow {
+  utilization: number
+  resets_at: string | null
+}
+
+/** Extra usage (overages) info for paid plans */
+export interface AnthropicExtraUsage {
+  is_enabled: boolean
+  monthly_limit: number | null
+  used_credits: number | null
+  utilization: number | null
+}
+
+/** Raw response from GET /api/oauth/usage */
+export interface AnthropicUsageResponse {
+  five_hour: AnthropicUsageWindow | null
+  seven_day: AnthropicUsageWindow | null
+  seven_day_oauth_apps: AnthropicUsageWindow | null
+  seven_day_opus: AnthropicUsageWindow | null
+  seven_day_sonnet: AnthropicUsageWindow | null
+  seven_day_cowork: AnthropicUsageWindow | null
+  iguana_necktie: AnthropicUsageWindow | null
+  extra_usage: AnthropicExtraUsage | null
+}
+
+/** Account info from the profile endpoint */
+export interface AnthropicAccount {
+  uuid: string
+  full_name: string
+  display_name: string
+  email: string
+  has_claude_max: boolean
+  has_claude_pro: boolean
+  created_at: string
+}
+
+/** Organization info from the profile endpoint */
+export interface AnthropicOrganization {
+  uuid: string
+  name: string
+  organization_type: string
+  billing_type: string
+  rate_limit_tier: string
+  has_extra_usage_enabled: boolean
+  subscription_status: string
+  subscription_created_at: string
+}
+
+/** Raw response from GET /api/oauth/profile */
+export interface AnthropicProfileResponse {
+  account: AnthropicAccount
+  organization: AnthropicOrganization
+}
+
+/** Resolved plan tier for display purposes */
+export type AnthropicPlanTier =
+  | "free"
+  | "pro"
+  | "max"
+  | "team"
+  | "enterprise"
+  | "unknown"

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,16 +3,19 @@ import { CodexProvider } from "./codex"
 import { ProxyProvider } from "./proxy"
 import { CopilotProvider } from "./copilot"
 import { ZaiProvider } from "./zai"
+import { AnthropicProvider } from "./anthropic"
 
 export const providers: Record<string, UsageProvider<unknown>> = {
   [CodexProvider.id]: CodexProvider as UsageProvider<unknown>,
   [ProxyProvider.id]: ProxyProvider as UsageProvider<unknown>,
   [CopilotProvider.id]: CopilotProvider as UsageProvider<unknown>,
   [ZaiProvider.id]: ZaiProvider as UsageProvider<unknown>,
+  [AnthropicProvider.id]: AnthropicProvider as UsageProvider<unknown>,
 }
 
 export { CodexProvider } from "./codex"
 export { ProxyProvider } from "./proxy"
 export { CopilotProvider } from "./copilot"
 export { ZaiProvider } from "./zai"
+export { AnthropicProvider } from "./anthropic"
 export type { UsageProvider } from "./base"

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,7 @@ export type UsageState = {
     codex: boolean
     proxy: boolean
     copilot: boolean
+    anthropic: boolean
   }
 }
 
@@ -21,6 +22,7 @@ export function createUsageState(): UsageState {
       codex: false,
       proxy: false,
       copilot: false,
+      anthropic: false,
     },
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface UsageConfig {
     proxy?: boolean
     copilot?: boolean
     zai?: boolean
+    anthropic?: boolean
   }
   modelGroups?: {
     showAll?: boolean
@@ -104,6 +105,33 @@ export interface ZaiQuota {
   }
 }
 
+export interface AnthropicUsageWindow {
+  utilization: number
+  resetsAt: string | null
+}
+
+export interface AnthropicExtraUsageInfo {
+  isEnabled: boolean
+  monthlyLimit: number | null
+  usedCredits: number | null
+  utilization: number | null
+}
+
+export interface AnthropicQuota {
+  fiveHour: AnthropicUsageWindow | null
+  sevenDay: AnthropicUsageWindow | null
+  sevenDayOAuthApps: AnthropicUsageWindow | null
+  sevenDayOpus: AnthropicUsageWindow | null
+  sevenDaySonnet: AnthropicUsageWindow | null
+  sevenDayCowork: AnthropicUsageWindow | null
+  iguanaNecktie: AnthropicUsageWindow | null
+  extraUsage: AnthropicExtraUsageInfo | null
+  planTier: string
+  organizationType: string | null
+  subscriptionStatus: string | null
+  accountEmail: string | null
+}
+
 export interface UsageSnapshot {
   timestamp: number
   provider: string
@@ -115,6 +143,7 @@ export interface UsageSnapshot {
   proxyQuota?: ProxyQuota
   copilotQuota?: CopilotQuota
   zaiQuota?: ZaiQuota
+  anthropicQuota?: AnthropicQuota
   updatedAt: number
   isMissing?: boolean
   missingReason?: string

--- a/src/ui/formatters/anthropic.ts
+++ b/src/ui/formatters/anthropic.ts
@@ -1,0 +1,77 @@
+/**
+ * Formats Anthropic subscription usage snapshots.
+ * Handles all plan tiers: Free, Pro, Max, Team, Enterprise.
+ * Displays 5h session, 7d weekly, model-specific, and extra usage windows.
+ */
+
+import type { UsageSnapshot, AnthropicQuota, AnthropicUsageWindow } from "../../types"
+import { formatBar, formatResetSuffixISO, formatMissingSnapshot } from "./shared"
+
+const PLAN_LABELS: Record<string, string> = {
+  free: "Free",
+  pro: "Pro ($20/mo)",
+  max: "Max",
+  team: "Team",
+  enterprise: "Enterprise",
+  unknown: "Unknown Plan",
+}
+
+interface WindowDisplay {
+  label: string
+  window: AnthropicUsageWindow
+}
+
+function collectWindows(quota: AnthropicQuota): WindowDisplay[] {
+  const windows: WindowDisplay[] = []
+
+  if (quota.fiveHour) windows.push({ label: "5h Session", window: quota.fiveHour })
+  if (quota.sevenDay) windows.push({ label: "7d Weekly", window: quota.sevenDay })
+  if (quota.sevenDayOpus) windows.push({ label: "7d Opus", window: quota.sevenDayOpus })
+  if (quota.sevenDaySonnet) windows.push({ label: "7d Sonnet", window: quota.sevenDaySonnet })
+  if (quota.sevenDayCowork) windows.push({ label: "7d Cowork", window: quota.sevenDayCowork })
+  if (quota.sevenDayOAuthApps) windows.push({ label: "7d OAuth", window: quota.sevenDayOAuthApps })
+  if (quota.iguanaNecktie) windows.push({ label: "Burst", window: quota.iguanaNecktie })
+
+  return windows
+}
+
+function formatWindow(label: string, window: AnthropicUsageWindow, labelWidth: number): string {
+  const pct = Math.max(0, 100 - window.utilization)
+  const reset = window.resetsAt ? formatResetSuffixISO(window.resetsAt) : ""
+  return `  ${(label + ":").padEnd(labelWidth + 1)} ${formatBar(pct)} ${pct.toFixed(0)}% left${reset}`
+}
+
+export function formatAnthropicSnapshot(snapshot: UsageSnapshot): string[] {
+  const quota = snapshot.anthropicQuota
+  if (!quota) return formatMissingSnapshot(snapshot)
+
+  const planLabel = PLAN_LABELS[quota.planTier] ?? quota.planTier
+  const status = quota.subscriptionStatus && quota.subscriptionStatus !== "active"
+    ? ` [${quota.subscriptionStatus}]`
+    : ""
+  const lines = [`→ [ANTHROPIC] Claude Code - ${planLabel}${status}`]
+
+  const windows = collectWindows(quota)
+  if (windows.length === 0 && !quota.extraUsage?.isEnabled) {
+    return formatMissingSnapshot(snapshot)
+  }
+
+  const labelWidth = Math.max(...windows.map(w => w.label.length), 10)
+  for (const { label, window } of windows) {
+    lines.push(formatWindow(label, window, labelWidth))
+  }
+
+  if (quota.extraUsage) {
+    lines.push("")
+    if (quota.extraUsage.isEnabled) {
+      const used = quota.extraUsage.usedCredits != null ? `$${quota.extraUsage.usedCredits.toFixed(2)}` : "N/A"
+      const limit = quota.extraUsage.monthlyLimit != null ? `$${quota.extraUsage.monthlyLimit.toFixed(2)}` : "no limit"
+      const pct = quota.extraUsage.utilization != null ? `${(100 - quota.extraUsage.utilization).toFixed(0)}% left` : ""
+      lines.push(`  Extra Usage:  ON  (${used} / ${limit})${pct ? ` ${pct}` : ""}`)
+    } else {
+      lines.push(`  Extra Usage:  OFF`)
+    }
+  }
+
+  return lines
+}

--- a/src/ui/formatters/shared.ts
+++ b/src/ui/formatters/shared.ts
@@ -56,7 +56,8 @@ export function formatMissingSnapshot(snapshot: UsageSnapshot): string[] {
   const instructions: Record<string, string> = {
     codex: "if you dont have codex oauth, please set your usage-config.jsonc to openai: false",
     proxy: "check your usage-config.jsonc. Default: endpoint http://localhost:8000, apiKey VerysecretKey. If you changed these during proxy setup, update your config to match. Or set proxy: false to disable.",
-    copilot: "if you are not running GitHub Copilot, please set your usage-config.jsonc to copilot: false"
+    copilot: "if you are not running GitHub Copilot, please set your usage-config.jsonc to copilot: false",
+    anthropic: "Anthropic OAuth token not found. Ensure you have logged into Claude Code (claude login) and an 'anthropic' entry exists in auth.json with a valid sk-ant-oat01-* access token. Or set anthropic: false in usage-config.jsonc to disable."
   }
 
   const lines = [`→ [${provider.toUpperCase()}] - ${instructions[provider] || ""}`]

--- a/src/ui/status.ts
+++ b/src/ui/status.ts
@@ -9,6 +9,7 @@ import type { UsageState } from "../state"
 import { formatProxySnapshot } from "./formatters/proxy"
 import { formatCopilotSnapshot } from "./formatters/copilot"
 import { formatZaiSnapshot } from "./formatters/zai"
+import { formatAnthropicSnapshot } from "./formatters/anthropic"
 import { formatBar, formatResetSuffix, formatMissingSnapshot } from "./formatters/shared"
 
 type UsageClient = PluginInput["client"]
@@ -44,6 +45,7 @@ function formatSnapshot(snapshot: UsageSnapshot): string[] {
   if (snapshot.provider === "proxy") return formatProxySnapshot(snapshot)
   if (snapshot.provider === "copilot") return formatCopilotSnapshot(snapshot)
   if (snapshot.provider === "zai-coding-plan") return formatZaiSnapshot(snapshot)
+  if (snapshot.provider === "anthropic") return formatAnthropicSnapshot(snapshot)
 
   const plan = snapshot.planType ? ` (${snapshot.planType.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase())})` : ""
   const lines = [`→ [${snapshot.provider.toUpperCase()}]${plan}`]

--- a/src/usage/config.ts
+++ b/src/usage/config.ts
@@ -45,7 +45,8 @@ export async function loadUsageConfig(): Promise<UsageConfig> {
     "openai": true,
     "proxy": true,
     "copilot": true,
-    "zai": true
+    "zai": true,
+    "anthropic": true
   }
 }
 `
@@ -60,6 +61,7 @@ export async function loadUsageConfig(): Promise<UsageConfig> {
         proxy: true,
         copilot: true,
         zai: true,
+        anthropic: true,
       },
     }
 

--- a/src/usage/fetch.ts
+++ b/src/usage/fetch.ts
@@ -9,7 +9,7 @@ import { loadUsageConfig } from "./config"
 import { loadMergedAuths } from "./auth/loader"
 import { resolveProviderAuths } from "./registry"
 
-const CORE_PROVIDERS = ["codex", "proxy", "copilot", "zai-coding-plan"]
+const CORE_PROVIDERS = ["codex", "proxy", "copilot", "zai-coding-plan", "anthropic"]
 
 export async function fetchUsageSnapshots(filter?: string): Promise<UsageSnapshot[]> {
   const target = resolveFilter(filter)
@@ -19,6 +19,7 @@ export async function fetchUsageSnapshots(filter?: string): Promise<UsageSnapsho
   const isEnabled = (id: string) => {
     if (id === "codex") return toggles.openai !== false
     if (id === "zai-coding-plan") return toggles.zai !== false
+    if (id === "anthropic") return toggles.anthropic !== false
     return (toggles as Record<string, boolean>)[id] !== false
   }
 
@@ -62,7 +63,8 @@ function resolveFilter(f?: string): string | undefined {
     codex: "codex", openai: "codex", gpt: "codex", 
     proxy: "proxy", agy: "proxy", gemini: "proxy",
     copilot: "copilot", github: "copilot",
-    zai: "zai-coding-plan", glm: "zai-coding-plan"
+    zai: "zai-coding-plan", glm: "zai-coding-plan",
+    anthropic: "anthropic", claude: "anthropic"
   }
   return f ? aliases[f.toLowerCase().trim()] : undefined
 }

--- a/src/usage/registry.ts
+++ b/src/usage/registry.ts
@@ -5,6 +5,7 @@
 import type { CodexAuth } from "../providers/codex"
 import type { CopilotAuthData } from "../providers/copilot/types"
 import type { ZaiAuth } from "../providers/zai/types"
+import type { AnthropicAuth } from "../providers/anthropic/types"
 
 export type AuthEntry = {
   type?: string
@@ -21,6 +22,7 @@ type ProviderAuthEntry =
   | { providerID: "codex"; auth: CodexAuth }
   | { providerID: "copilot"; auth: CopilotAuthData }
   | { providerID: "zai-coding-plan"; auth: ZaiAuth }
+  | { providerID: "anthropic"; auth: AnthropicAuth }
 
 type ProviderDescriptor = {
   id: ProviderAuthEntry["providerID"]
@@ -54,6 +56,15 @@ const providerDescriptors: ProviderDescriptor[] = [
     requiresOAuth: false,
     buildAuth: (entry) => ({
       key: entry.key || entry.access || "",
+    }),
+  },
+  {
+    id: "anthropic",
+    authKeys: ["anthropic", "claude"],
+    requiresOAuth: true,
+    buildAuth: (entry) => ({
+      access: entry.access || "",
+      refresh: entry.refresh,
     }),
   },
 ]


### PR DESCRIPTION
Implements tracking for Anthropic subscriptions (Free, Pro, Max, Team, and Enterprise tiers) via OAuth. Fetches 5h and 7d usage windows and provides a dedicated UI formatter for subscription status.